### PR TITLE
Base/services

### DIFF
--- a/AnimePortal/Controllers/JwtAuthController.cs
+++ b/AnimePortal/Controllers/JwtAuthController.cs
@@ -1,4 +1,4 @@
-﻿using BLL.Abstractions;
+﻿using BLL.Abstractions.Interfaces;
 using BLL.Jwt;
 using Core.Abstractions.DTOs.Interfaces;
 using Core.DB;

--- a/AnimePortal/Program.cs
+++ b/AnimePortal/Program.cs
@@ -2,7 +2,7 @@ using AnimePortalAuthServer.Extension;
 using AnimePortalAuthServer.Extensions;
 using AnimePortalAuthServer.Middlewares;
 using BLL;
-using BLL.Abstractions;
+using BLL.Abstractions.Interfaces;
 using BLL.Jwt;
 using Core.DB;
 using Core.DI;

--- a/AnimePortal/Program.cs
+++ b/AnimePortal/Program.cs
@@ -4,12 +4,14 @@ using AnimePortalAuthServer.Middlewares;
 using BLL;
 using BLL.Abstractions.Interfaces;
 using BLL.Jwt;
+using CloudinaryDotNet;
 using Core.DB;
 using Core.DI;
 using DAL;
 using DAL.Abstractions.Interfaces;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -55,7 +57,7 @@ builder.Services.AddScoped<IUserManipulator<User>, JwtUserManipulator>();
 
 //Configurations
 builder.Services.Configure<JwtConfigurations>(builder.Configuration.GetSection("JWT"));
-
+builder.Services.Configure<CloudinarySettings>(builder.Configuration.GetSection("CloudinarySettings"));
 //Mapper
 builder.Services.AddAutoMapper(typeof(Program));
 

--- a/AnimePortal/Program.cs
+++ b/AnimePortal/Program.cs
@@ -1,17 +1,14 @@
 using AnimePortalAuthServer.Extension;
 using AnimePortalAuthServer.Extensions;
-using AnimePortalAuthServer.Middlewares;
 using BLL;
 using BLL.Abstractions.Interfaces;
 using BLL.Jwt;
-using CloudinaryDotNet;
 using Core.DB;
 using Core.DI;
 using DAL;
 using DAL.Abstractions.Interfaces;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/AnimePortal/appsettings.json
+++ b/AnimePortal/appsettings.json
@@ -6,17 +6,19 @@
     }
   },
   "AllowedHosts": "*",
+    "CloudinarySettings": {
+      "CloudName": "",
+      "ApiKey": "",
+      "ApiSecret": ""
+    },
   "JWT": {
     "Lifetime": 2,
     "RefreshLifetime": 24,
     "SecretCode": "whoreadthiswillturntogay",
     "Issuer": "",
     "Audience": ""
-  },
-  {
-    "CloudinarySettings": {
-    }
   }
+ 
 
 
 }

--- a/AnimePortal/appsettings.json
+++ b/AnimePortal/appsettings.json
@@ -12,6 +12,11 @@
     "SecretCode": "whoreadthiswillturntogay",
     "Issuer": "",
     "Audience": ""
+  },
+  {
+    "CloudinarySettings": {
+    }
   }
+
 
 }

--- a/BLL.Abstractions/BLL.Abstractions.csproj
+++ b/BLL.Abstractions/BLL.Abstractions.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CloudinaryDotNet" Version="1.20.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />
   </ItemGroup>
 

--- a/BLL.Abstractions/Interfaces/ICrudService.cs
+++ b/BLL.Abstractions/Interfaces/ICrudService.cs
@@ -1,7 +1,7 @@
 ﻿using Core.DB;
 using System.Linq.Expressions;
 
-namespace BLL.Abstractions
+namespace BLL.Abstractions.Interfaces
 {
     public interface ICrudService<T> where T : BaseEntity
     {

--- a/BLL.Abstractions/Interfaces/IPhotoService.cs
+++ b/BLL.Abstractions/Interfaces/IPhotoService.cs
@@ -1,0 +1,11 @@
+﻿using CloudinaryDotNet.Actions;
+using Microsoft.AspNetCore.Http;
+
+namespace BLL.Abstractions.Interfaces
+{
+    public interface IPhotoService
+    {
+        Task<ImageUploadResult> UploadPhotoAsync(IFormFile photo);
+        Task<DeletionResult> DeletePhotoAsync(string cloudinaryId);
+    }
+}

--- a/BLL.Abstractions/Interfaces/IUserManipulator.cs
+++ b/BLL.Abstractions/Interfaces/IUserManipulator.cs
@@ -1,7 +1,7 @@
 ﻿using Core.Abstractions.DTOs.Interfaces;
 using Core.DTOs.Jwt;
 
-namespace BLL.Abstractions
+namespace BLL.Abstractions.Interfaces
 {
     public interface IUserManipulator<T>
     {

--- a/BLL/CrudForEntity.cs
+++ b/BLL/CrudForEntity.cs
@@ -1,4 +1,4 @@
-﻿using BLL.Abstractions;
+﻿using BLL.Abstractions.Interfaces;
 using Core.DB;
 using DAL;
 using Microsoft.EntityFrameworkCore.ChangeTracking;

--- a/BLL/Jwt/JwtGeneralHelper.cs
+++ b/BLL/Jwt/JwtGeneralHelper.cs
@@ -1,4 +1,4 @@
-﻿using BLL.Abstractions;
+﻿using BLL.Abstractions.Interfaces;
 using Core.ClaimNames;
 using Core.DB;
 using Core.DI;

--- a/BLL/Jwt/JwtRefresher.cs
+++ b/BLL/Jwt/JwtRefresher.cs
@@ -1,4 +1,4 @@
-﻿using BLL.Abstractions;
+﻿using BLL.Abstractions.Interfaces;
 using Core.ClaimNames;
 using Core.DB;
 using Core.DTOs.Jwt;

--- a/BLL/Jwt/JwtUserManipulator.cs
+++ b/BLL/Jwt/JwtUserManipulator.cs
@@ -1,4 +1,4 @@
-﻿using BLL.Abstractions;
+﻿using BLL.Abstractions.Interfaces;
 using Core.Abstractions.DTOs.Interfaces;
 using Core.ClaimNames;
 using Core.DB;

--- a/BLL/Services/PhotoService.cs
+++ b/BLL/Services/PhotoService.cs
@@ -19,10 +19,12 @@ namespace BLL.Services
 
         public PhotoService(IOptions<CloudinarySettings> cloudinaryConfig)
         {
+            CloudinarySettings cloudinaryConfiguration = cloudinaryConfig.Value ?? throw new ArgumentNullException(nameof(cloudinaryConfig));
+
             Account account = new(
-                cloudinaryConfig.Value.CloudName,
-                cloudinaryConfig.Value.ApiKey,
-                cloudinaryConfig.Value.ApiSecret);
+                cloudinaryConfiguration.CloudName,
+                cloudinaryConfiguration.ApiKey,
+                cloudinaryConfiguration.ApiSecret);
             _cloudinary = new Cloudinary(account);
             _cloudinary = new Cloudinary(account);
         }

--- a/BLL/Services/PhotoService.cs
+++ b/BLL/Services/PhotoService.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BLL.Abstractions.Interfaces;
+using CloudinaryDotNet;
+using CloudinaryDotNet.Actions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+
+namespace BLL.Services
+{
+    public class PhotoService : IPhotoService
+    {
+        private readonly Cloudinary _cloudinary;
+
+        public PhotoService(IConfiguration config)
+        {
+            Account account = new(config.GetSection("CloudinarySettings:CloudName").Value,
+                config.GetSection("CloudinarySettings:ApiKey").Value,
+                config.GetSection("ASPNETCORE_CloudinarySettings:ApiSecret").Value);
+            _cloudinary = new Cloudinary(account);
+        }
+
+        public async Task<ImageUploadResult> UploadPhotoAsync(IFormFile photo)
+        {
+            var uploadResult = new ImageUploadResult();
+            if (photo.Length > 0)
+            {
+                await using var stream = photo.OpenReadStream();
+                var uploadParams = new ImageUploadParams
+                {
+                    File = new FileDescription(photo.FileName, stream),
+                };
+                uploadResult = await _cloudinary.UploadAsync(uploadParams);
+            }
+            return uploadResult;
+        }
+
+        public async Task<DeletionResult> DeletePhotoAsync(string cloudinaryId)
+        {
+            DeletionParams deleteParams = new (cloudinaryId);
+            var result = await _cloudinary.DestroyAsync(deleteParams);
+            return result;
+        }
+    }
+}

--- a/BLL/Services/PhotoService.cs
+++ b/BLL/Services/PhotoService.cs
@@ -6,8 +6,10 @@ using System.Threading.Tasks;
 using BLL.Abstractions.Interfaces;
 using CloudinaryDotNet;
 using CloudinaryDotNet.Actions;
+using Core.DI;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace BLL.Services
 {
@@ -15,11 +17,13 @@ namespace BLL.Services
     {
         private readonly Cloudinary _cloudinary;
 
-        public PhotoService(IConfiguration config)
+        public PhotoService(IOptions<CloudinarySettings> cloudinaryConfig)
         {
-            Account account = new(config.GetSection("CloudinarySettings:CloudName").Value,
-                config.GetSection("CloudinarySettings:ApiKey").Value,
-                config.GetSection("ASPNETCORE_CloudinarySettings:ApiSecret").Value);
+            Account account = new(
+                cloudinaryConfig.Value.CloudName,
+                cloudinaryConfig.Value.ApiKey,
+                cloudinaryConfig.Value.ApiSecret);
+            _cloudinary = new Cloudinary(account);
             _cloudinary = new Cloudinary(account);
         }
 
@@ -38,11 +42,10 @@ namespace BLL.Services
             return uploadResult;
         }
 
-        public async Task<DeletionResult> DeletePhotoAsync(string cloudinaryId)
+        public Task<DeletionResult> DeletePhotoAsync(string cloudinaryId)
         {
-            DeletionParams deleteParams = new (cloudinaryId);
-            var result = await _cloudinary.DestroyAsync(deleteParams);
-            return result;
+            DeletionParams deleteParams = new(cloudinaryId);
+            return _cloudinary.DestroyAsync(deleteParams);
         }
     }
 }

--- a/Core/DI/CloudinaryConfiguration.cs
+++ b/Core/DI/CloudinaryConfiguration.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Core.DI
+{
+    public class CloudinarySettings
+    {
+        public string? CloudName { get; set; }
+        public string? ApiKey { get; set; }
+        public string? ApiSecret { get; set; }
+    }
+}


### PR DESCRIPTION
Added PhotoService to handle the deletion and saving of photos to the cloud.

The PhotoService class is responsible for interacting with the Cloudinary API to upload, delete, and retrieve photos. It the provided API key and secret, and provides methods for uploading and deleting photos from the cloud.

The IPhotoService interface defines the contract for the PhotoService, which allows it to be easily mocked and tested.